### PR TITLE
Move main.py into package and add vanity CLI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -199,12 +199,12 @@ There are a few ways to run ``omop2obo``. An example workflow is provided below.
 
 |
 
-*COMMAND LINE* ➞ `main.py <https://github.com/callahantiff/OMOP2OBO/blob/master/main.py>`_
+*COMMAND LINE* ➞ after installing with pip, the `omop2obo` command is available directly in your shell.
 
 .. code:: bash
 
-  python main.py --help
-  Usage: main.py [OPTIONS]
+  omop2obo --help
+  Usage: omop2obo [OPTIONS]
 
   The OMOP2OBO package provides functionality to assist with mapping OMOP standard clinical terminology
   concepts to OBO terms. Successfully running this program requires several input parameters, which are
@@ -246,7 +246,7 @@ If you follow the instructions for how to format clinical data (`here <https://g
 
 .. code:: bash
 
- python main.py --clinical_domain condition --onts hp --onts mondo --clinical_data resources/clinical_data/omop2obo_conditions_june2020.csv
+ $ omop2obo --clinical_domain condition --onts hp --onts mondo --clinical_data resources/clinical_data/omop2obo_conditions_june2020.csv
 
 |
 

--- a/omop2obo/__main__.py
+++ b/omop2obo/__main__.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+
+"""Entrypoint module, in case you use `python -m omop2obo`.
+
+Why does this file exist, and why ``__main__``? For more info, read:
+
+- https://www.python.org/dev/peps/pep-0338/
+- https://docs.python.org/3/using/cmdline.html#cmdoption-m
+"""
+
+from .main import main
+
+if __name__ == '__main__':
+    main()

--- a/omop2obo/main.py
+++ b/omop2obo/main.py
@@ -1,6 +1,17 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+"""Command line interface for :mod:`omop2obo`.
+
+Why does this file exist, and why not put this in ``__main__``? You might be tempted to import things from ``__main__``
+later, but that will cause problems--the code will get executed twice:
+
+- When you run ``python3 -m omop2obo`` python will execute``__main__.py`` as a script.
+  That means there won't be any ``omop2obo.__main__`` in ``sys.modules``.
+- When you import __main__ it will get executed again (as a module) because
+  there's no ``omop2obo.__main__`` in ``sys.modules``.
+
+.. seealso:: https://click.palletsprojects.com/en/7.x/setuptools/#setuptools-integration
+"""
 
 # import needed libraries
 import click

--- a/omop2obo_notebook.ipynb
+++ b/omop2obo_notebook.ipynb
@@ -41,7 +41,7 @@
    "source": [
     "## Notebook Purpose\n",
     "\n",
-    "This notebook serves as a `main` file for the `OMOP2OBO` project. This scripts walks through this program step-by-step and generates mappings between Observational Medical Outcomes Partnership (OMOP) common data model and ontologies in the Open Biological and Biomedical Ontologies (OBO) Foundry. There is also a command line version of this file ([`main.py`](https://github.com/callahantiff/OMOP2OBO/blob/master/main.py)). Please see the [README](https://github.com/callahantiff/OMOP2OBO) for more information.\n",
+    "This notebook serves as a `main` file for the `OMOP2OBO` project. This scripts walks through this program step-by-step and generates mappings between Observational Medical Outcomes Partnership (OMOP) common data model and ontologies in the Open Biological and Biomedical Ontologies (OBO) Foundry. There is also a command line version of this file (`omop2obo`) that's automatically installed with OMOP2OBO. Please see the [README](https://github.com/callahantiff/OMOP2OBO) for more information.\n",
     "\n",
     "**OMOP2OBO Workflow**  \n",
     "The figure below provides a high-level overview of the `OMOP2OBO` mapping algorithm. The steps code in this notebook aligns to the steps shown in this figure. The only step that is not run is querying an OMOP instance. Since it is highly likely that these instance contain patient data, we assume that data has already been obtained and saved in the `resources/clinical_data/` repository. See project [README](https://github.com/callahantiff/OMOP2OBO) for additional information.\n",

--- a/setup.py
+++ b/setup.py
@@ -80,4 +80,9 @@ setup(
         'scikit-learn==0.23.2',
         'tqdm==4.54.1'],
     extras_require=extras,
+    entry_points={
+        "console_scripts": [
+            'omop2obo = omop2obo.main:main',
+        ],
+    },
 )


### PR DESCRIPTION
Closes #56

This PR does the following:

1. Moves `main.py` into the main package hierarchy. My personal preference is to name the file `cli.py`, but I'll leave this as an option to you
2. Adds a vanity CLI using python entrypings (see changes in setup.py)
3. Updates documentation in README.rst and jupyter notebook
4. Bonus: add `__main__.py` for usage as `python -m omop2obo` as well as docs in the top explaining what's going on

Happy ontologizing!